### PR TITLE
Bugfix: change ClientHandler interface to Router.

### DIFF
--- a/app/config/sockets.yml
+++ b/app/config/sockets.yml
@@ -40,7 +40,7 @@ services:
   socket_client_handler_host:
     class: "%socket_class%"
     factory_service: socket_factory
-    factory_method: createReply
+    factory_method: createRouter
     arguments:
       - "bind"
       - "%client_handler%"


### PR DESCRIPTION
Because the ClientHandler interface was a reply socket, it could only handle a single client at a time.

By changing to a router socket, multi-client functionality is restored.

See the [ZeroMQ guide](http://zguide.zeromq.org/page:all#Recap-of-Request-Reply-Sockets) for more information.
