### PR TITLE
MAX_MANAGER_DELAY had a very high value of 1 second.

### DIFF
--- a/src/AlphaRPC/Common/AlphaRPC.php
+++ b/src/AlphaRPC/Common/AlphaRPC.php
@@ -23,7 +23,7 @@ class AlphaRPC
      * Maximum time the handlers have to respond to a request
      * before it is considered to be down.
      */
-    const MAX_MANAGER_DELAY = 1000;
+    const MAX_MANAGER_DELAY = 100;
 
     /**
      * Default blocking timeout for a client fetching a response.


### PR DESCRIPTION
When a client handler was not running on a target dsn, it took over a second to timeout and retry at the alternative manager.
