### PR TITLE
Fix worker handler scalability

### DIFF
--- a/src/AlphaRPC/Manager/WorkerHandler/Worker.php
+++ b/src/AlphaRPC/Manager/WorkerHandler/Worker.php
@@ -12,6 +12,8 @@
 
 namespace AlphaRPC\Manager\WorkerHandler;
 
+use AlphaRPC\Manager\Request;
+
 /**
  * @author Reen Lokum <reen@alphacomm.nl>
  * @package AlphaRPC


### PR DESCRIPTION
The Worker Handler dispatched request by looping through the
requests. When there are many requests, this causes a timeout
on workers for which there are no (or only a few) requests.

Therefore, the Worker Handler will now dispatch the requests
by looping through the requested actions. Since this list
is usually significantly shorter, the timeouts go away.