### PR TITLE
Only change state when new state is different

### DIFF
--- a/src/AlphaRPC/Worker/Worker.php
+++ b/src/AlphaRPC/Worker/Worker.php
@@ -93,7 +93,13 @@ class Worker implements LoggerAwareInterface
      */
     public function setState($state)
     {
-        $this->getLogger()->debug('Changing state from: '.$this->getState().' to: '.$state.'.');
+        $oldState = $this->getState();
+
+        if ($oldState === $state) {
+            return $this;
+        }
+
+        $this->getLogger()->debug('Changing state from: '.$oldState.' to: '.$state.'.');
         $this->state = $state;
 
         return $this;


### PR DESCRIPTION
Prevent the DEBUG log being filled with messages like this:

worker.DEBUG: Changing state from: ready to: ready.