### PR TITLE
Remove the group name validation when generating a supervisor config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
+/.idea
 /nbproject
 /vendor
 /build
 /config/runtime.php
 /config/supervisord.ini
+/app/config/supervisord.ini
 /logs/*.log
 /alpharpc_*.yml
 composer.lock

--- a/src/AlphaRPC/Console/Command/GenerateSupervisorConfig.php
+++ b/src/AlphaRPC/Console/Command/GenerateSupervisorConfig.php
@@ -78,12 +78,6 @@ class GenerateSupervisorConfig extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $group = $input->getArgument('group');
-        if (!preg_match('/^[A-Za-z0-9]+$/', $group)) {
-            $output->writeln(array(
-                '<error>Invalid group, should be alphanumeric</error>',
-            ));
-            exit;
-        }
 
         $outputFile = $input->getOption('output-file');
         if (!$outputFile) {


### PR DESCRIPTION
This allows the group name alpharpc-staging for example
Also gitignore the generated supervisor config